### PR TITLE
Aviator 0.5.1

### DIFF
--- a/net.natesales.Aviator.yml
+++ b/net.natesales.Aviator.yml
@@ -12,12 +12,8 @@ finish-args:
   - --filesystem=host
 
 build-options: 
-  append-path: /usr/lib/sdk/rust-stable/bin
-  env: 
-    CARGO_HOME: /run/build/done/cargo
-    PROTOC: /app/bin/protoc
-  prepend-ld-library-path: /usr/lib/sdk/llvm16/lib
-  prepend-path: /usr/lib/sdk/llvm16/bin
+  prepend-ld-library-path: /usr/lib/sdk/llvm17/lib
+  prepend-path: /usr/lib/sdk/llvm17/bin
 
 cleanup:
   - /include
@@ -35,6 +31,10 @@ modules:
     buildsystem: cmake-ninja
     builddir: true
     config-opts:
+      - "-DCMAKE_C_COMPILER=clang"
+      - "-DCMAKE_CXX_COMPILER=clang++"
+      - "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld"
+      - "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld"
       - "-DCMAKE_BUILD_TYPE=Release"
       - "-DCMAKE_CXX_FLAGS=-O3 -flto"
       - "-DCMAKE_C_FLAGS=-O3 -flto"
@@ -49,7 +49,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/gianni-rosato/svt-av1-psy
-        commit: 5d60263a420305665c0d0a303c815cd5d3daf950
+        commit: 7ae86e207b753a21d155ada248b83a697eb45133
 
   - name: ffmpeg
     config-opts:
@@ -92,4 +92,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/gianni-rosato/aviator
-        commit: 3510ecf8f27732bd181b878defbce52ec56b7cd2
+        commit: b8c74c1014c156be6208026451c6fa0dc6347d81


### PR DESCRIPTION
- TL;DR, mostly SVT-AV1-PSY improvements. But still exciting, nonetheless!
- Open GOP toggle has been renamed to oGOP
- Speed -1 and -2 are now supported with a warning when you go below Speed 3. Speed -2 can take over 8 hours for a minute of video on a Ryzen 9
- New "Perceptual Tuning" enables some new SVT-AV1-PSY features by default to improve visual fidelity at the cost of metric scores
- "-mapping_family 1" is now enabled in libopus, so surround encodes will benefit from Opus's multichannel optimizations
- Modified SVT-AV1 defaults, notably re-enabling temporal filtering by default